### PR TITLE
Add paragraph to team practices doc encouraging upstream contributions

### DIFF
--- a/practice.md
+++ b/practice.md
@@ -19,7 +19,7 @@ There are potentially other cases where copyright is involved: where contractors
 
 ### Contributing back to outside projects
 
-18F employees are encouraged to contribute back any modifications or improvements they make to open source software projects outside 18F -- whether government or non-government -- in the course of their work.
+18F staff are encouraged to contribute back any modifications or improvements they make to open source software projects outside 18F -- whether government or non-government -- in the course of their work. When 18F staff begin modifications to outside work, they should plan with eventual upstream contribution in mind.
 
 In terms of licensing: as works of the government, employee contributions are public domain in the United States, regardless of the outside project's contribution agreement. This does not change the overall license status of the outside project.
 


### PR DESCRIPTION
This adds a section explicitly encouraging teammates to take any improvements they make to outside open source projects in the course of their work and contribute them upstream.

It does what I think is a competent but not totally rigorous job of explaining why this is okay, and how government works interact with outside open source projects' contributing agreements.

I'd love @benbalter's :eyes: on this one, along with @rjmajma @leah and @yuda.
