### PR TITLE
remove redundant licensing paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,3 @@ For 18F team members, we have guidance on how 18F puts this policy into practice
 ### Credits
 
 This policy was originally forked from the [Consumer Financial Protection Bureau's policy](https://github.com/cfpb/source-code-policy). Thanks also to [@benbalter](https://github.com/benbalter) for his [insights regarding CFPB's intial policy](http://ben.balter.com/2012/04/10/whats-missing-from-cfpbs-awesome-new-source-code-policy/).
-
-
-### Public domain
-
-This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
-
-> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
->
-> All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/practice.md
+++ b/practice.md
@@ -29,7 +29,7 @@ As [the Free Software Foundation says](https://www.gnu.org/licenses/gpl-faq.html
 
 #### How to license 18F repos
 
-When you create a repo, add a [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) file, and add a [paragraph to the end of your README](README.md#public-domain).
+When you create a repo, add a [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 The preceding links are to our standard boilerplate for each of those, so you can just copy and paste them. In some cases, you may need to customize them for your use -- for example, if you've forked a project that originated from outside the government.
 
@@ -46,9 +46,6 @@ You can then initialize a new 18F repository's license information with:
 ```bash
 18f-init
 ```
-
-It's also recommended to copy and paste [this paragraph for the end of your README](https://github.com/18F/open-source-policy/blob/master/README.md#public-domain) that sums up what's going on.
-
 
 ### Working in public
 


### PR DESCRIPTION
The information contained in the README paragraph is already contained in the LICENSE and CONTRIBUTING files (which is the convention for GitHub repositories), and I don't see a big benefit of the redundancy.