### PR TITLE
Add a README template for new repos

### DIFF
--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -1,0 +1,20 @@
+# [Repo Name]
+
+## Contributing
+
+See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
+
+### Branch flow
+
+- Main branch: `master`
+- Development branch: `develop`
+
+## Licensing
+
+### Public domain
+
+This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
+
+> This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+>
+> All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -9,9 +9,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 - Main branch: `master`
 - Development branch: `develop`
 
-## Licensing
-
-### Public domain
+## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):
 

--- a/practice.md
+++ b/practice.md
@@ -32,7 +32,7 @@ As [the Free Software Foundation says](https://www.gnu.org/licenses/gpl-faq.html
 
 #### How to license 18F repos
 
-When creating a repo, add a [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) file, and add a [paragraph to the end of its README](README.md#public-domain).
+When creating a repo, add a [LICENSE.md](LICENSE.md) and [CONTRIBUTING.md](CONTRIBUTING.md) file, and add/edit the [README.md template](README_TEMPLATE.md).
 
 The preceding links are to our standard boilerplate for each of those, so you can just copy and paste them. In some cases, you may need to customize them for your use -- for example, if you've forked a project that originated from outside the government.
 
@@ -54,7 +54,8 @@ Want to take it even further and create the repo at the same time?
 
 ```bash
 alias create-repo="mkdir \!* && cd \!* && git init ."
-alias create-18f-repo="create-repo \!* && 18f-init && git add . && git commit -m 'initial commit'"
+alias create-readme="curl -s https://raw.githubusercontent.com/18F/open-source-policy/master/README_TEMPLATE.md -o README.md"
+alias create-18f-repo="create-repo \!* && 18f-init && create-readme && sed 's/[Repo Name]/$(/usr/bin/basename $(pwd))/' README.md && git add . && git commit -m 'initial commit'"
 ```
 
 Then create a repo and license it with:
@@ -63,7 +64,7 @@ Then create a repo and license it with:
 create-18f-repo new-project-name
 ```
 
-It's also recommended to copy and paste [this paragraph for the end of your README](https://github.com/18F/open-source-policy/blob/master/README.md#public-domain) that sums up what's going on.
+Even if you don't create a repo, it's recommended to use [this README.md template](README_TEMPLATE.md) that sums up what's going on.
 
 ### Accepting contributions from the public
 


### PR DESCRIPTION
This started out as a place to put information about branching structure, but also seemed like a good way to make README creation match the flow for LICENSE and CONTRIBUTING.

The heading structure is a little busy, in part because I assumed that the use of `h3` in this repo for the "License" part of the README was intentional. If it can be bumped up to `h2`, that can probably be simplified