### PR TITLE
Add exception for passwords, configs, etc

### DIFF
--- a/policy.md
+++ b/policy.md
@@ -56,6 +56,10 @@ There is a misconception that FOSS that is distributed to the public should not 
 
 In addition, while open source licenses permit the user to modify FOSS for internal use without obligating them to distribute source code to the public, when the user chooses to distribute the modified FOSS outside the user's organization, then the code is subject to whatever license it carries.
 
+## Sensitive Information
+
+Passwords, API tokens, SSH keys, protected configurations (like IP addresses), PII or any other "sensitive" information shall not be committed to a public repository. The publication of any of these items to a public source will be considered a security incident.
+
 ## Exceptions
 
 The only conditions where code shall not be developed and released in the open are:

--- a/practice.md
+++ b/practice.md
@@ -109,10 +109,12 @@ If you think something will benefit 18F and is worth the time, then that's valua
 
 #### Exceptions
 
-Password, protected configurations (such as IP addresses), authentication tokens and service keys should always be kept in a secrets store outside of a public repository.
-
 18F currently has **no projects** for which we will not ever release the source code.
 
 18F has one project where source code will be released at a later time:
 
 * [US Citizenship & Immigration Services](http://www.uscis.gov/) - Project agreement pre-dated the creation of 18F's open source policy. 18F will work with USCIS to coordinate publication of source code as components are publicly released. Components based on existing open source projects will remain open throughout development.
+
+#### Sensitive Information
+
+Password, protected configurations (such as IP addresses), authentication tokens and service keys should always be kept in a secrets store outside of a public repository.

--- a/practice.md
+++ b/practice.md
@@ -109,6 +109,8 @@ If you think something will benefit 18F and is worth the time, then that's valua
 
 #### Exceptions
 
+Password, protected configurations (such as IP addresses), authentication tokens and service keys should always be kept in a secrets store outside of a public repository.
+
 18F currently has **no projects** for which we will not ever release the source code.
 
 18F has one project where source code will be released at a later time:


### PR DESCRIPTION
(Adding context) In the process of reviewing our policies with our auditors we found that there is no place where we say that password or secrets should be kept out of open source. I can commit an admin key without violating any 18F policy.

I think its not a bad idea to change that.