### PR TITLE
Clarifying definition of a public vulnerability

### DIFF
--- a/practice.md
+++ b/practice.md
@@ -100,7 +100,7 @@ Sensitive information we need to protect includes, but is not limited to:
 
 * Information an attacker could plausibly use to help them compromise a system. Examples:
     * **Secret keys:** Passwords, passcodes, access codes, access tokens, API keys, TLS keys, SSH keys, OAuth secrets, or any other “secret keys” that protect access to something.
-    * **Undisclosed vulnerabilities:** If we know of a security problem or potential security problem with our code that isn’t already publicly-known (such as a vulnerability that isn’t easy to find with scanning tools), we shouldn’t write publicly about it until we fix it.
+    * **Undisclosed vulnerabilities:** If we know of a security problem or potential security problem with our code that isn’t already publicly-known (such as a vulnerability that can’t be found with a publicly-available open source scanning tool run on the public-facing system), we shouldn’t write publicly about it until we fix it.
 * Nonpublic information in general about vulnerabilities, including attribution/source information (such as how and when we learned about a vulnerability, if the disclosure to us was not public).
 * We may wish to withhold some non-18F IP addresses. If something looks like an IP address, ask 18F Infrastructure before publishing that info.
 * Personally Identifiable Information (PII). Here’s [OMB's definition and GSA's policy](http://www.gsa.gov/portal/content/104256). 18F also has [guidance for systems involving PII](https://pages.18f.gov/before-you-ship/security/pii/).


### PR DESCRIPTION
Under the definition of "Undisclosed vulnerabilities", "isn't easy to find with scanning tools" [was a bit subjective](https://18f.slack.com/archives/cloud-gov/p1475515842000830), so here's a suggested improvement: "can't be found with a publicly-available open source scanning tool run on the public-facing system".

cc @wslack @afeld @NoahKunin @konklone as people who may have opinions
