### PR TITLE
swap his-or-her for their

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@ This is a human-readable summary of the [Legal Code (read the full text)](https:
 ### No copyright
 
 The person who associated a work with this deed has dedicated the work to
-the public domain by waiving all of his or her rights to the work worldwide
+the public domain by waiving all of their rights to the work worldwide
 under copyright law, including all related and neighboring rights, to the
 extent allowed by law.
 


### PR DESCRIPTION
I use they as a pronoun, and noticed that this licence uses 'his or her' wording, so this pull request makes it easier for me to use the licence. It might also be worded *waiving all rights to the work* to avoid pronouns entirely.