### PR TITLE
Make license summary slightly more concise

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@ This is a human-readable summary of the [Legal Code (read the full text)](https:
 ### No copyright
 
 The person who associated a work with this deed has dedicated the work to
-the public domain by waiving all of their rights to the work worldwide
+the public domain by waiving all rights to the work worldwide
 under copyright law, including all related and neighboring rights, to the
 extent allowed by law.
 


### PR DESCRIPTION
This follows @janearc's suggestion in https://github.com/18F/open-source-policy/pull/68#issue-194634234 that we use `all rights` to avoid pronouns entirely and be more concise.