### PR TITLE
Document why a repo is private

### DIFF
--- a/policy.md
+++ b/policy.md
@@ -66,8 +66,6 @@ The only conditions where code shall not be developed and released in the open a
 
 These decisions will be made as needed by the 18F Infrastructure team, which will lead an interdisciplinary team to review the conditions under which code will not be made available publicly. Any further exemptions will be rare, documented publicly, and the result of compelling interest.
 
-An explanation of the decision not to release the code publicly will be documented and a link to that explanation will be provided in the code's README to preserve that knowledge and so the decision can be revisited in the future if circumstances change.
-
 If an existing solution cannot be found in the open source community, 18F may consider other options, including creating an open source solution itself. Ultimately, the software that best meets the needs and mission of 18F should be used.
 
 ## Thanks

--- a/policy.md
+++ b/policy.md
@@ -66,6 +66,8 @@ The only conditions where code shall not be developed and released in the open a
 
 These decisions will be made as needed by the 18F Infrastructure team, which will lead an interdisciplinary team to review the conditions under which code will not be made available publicly. Any further exemptions will be rare, documented publicly, and the result of compelling interest.
 
+An explanation of the decision not to release the code publicly will be documented and a link to that explanation will be provided in the code's README to preserve that knowledge and so the decision can be revisited in the future if circumstances change.
+
 If an existing solution cannot be found in the open source community, 18F may consider other options, including creating an open source solution itself. Ultimately, the software that best meets the needs and mission of 18F should be used.
 
 ## Thanks

--- a/practice.md
+++ b/practice.md
@@ -111,7 +111,7 @@ There are more categories of controlled unclassified information to protect; tho
 
 ### Private repositories
 
-If the 18F Infrastructure team determines that a repository should not be public, as described in the [open source policy](policy.md#Exceptions), the reasoning should be documented and a link to that reasoning provided in the repository's `README` to preserve that knowledge and so the decision can be revisited in the future if circumstances change.  If the underlying reasons for making the repository private are not themselves sensitive, this explanation can be placed directly in the `README`.
+If the 18F Infrastructure team determines that a repository should not be public, as described in the [open source policy](policy.md#exceptions), the reasoning should be documented and a link to that reasoning provided in the repository's `README` to preserve that knowledge and so the decision can be revisited in the future if circumstances change.  If the underlying reasons for making the repository private are not themselves sensitive, this explanation can be placed directly in the `README`.
 
 ### Managing 18F resources
 

--- a/practice.md
+++ b/practice.md
@@ -109,6 +109,10 @@ Sensitive information we need to protect includes, but is not limited to:
 
 There are more categories of controlled unclassified information to protect; those are just the kinds that we work with most often. [Here’s the complete list.](https://www.archives.gov/cui/registry)
 
+### Private repositories
+
+If the 18F Infrastructure team determines that a repository should not be public, as described in the [open source policy](policy.md#Exceptions), the reasoning should be documented and a link to that reasoning provided in the repository's `README` to preserve that knowledge and so the decision can be revisited in the future if circumstances change.  If the underlying reasons for making the repository private are not themselves sensitive, this explanation can be placed directly in the `README`.
+
 ### Managing 18F resources
 
 18F intends to produce great software for the American people. That means not just rushing through projects to get them working as fast as possible, but managing [technical debt](https://en.wikipedia.org/wiki/Technical_debt) with an eye towards usability and reusability.


### PR DESCRIPTION
From https://gsa-tts.slack.com/archives/C02KXM98G/p1490369907134478

The idea is to capture why a repo is private and make that accessible from within the repo itself, so folks in the future will understand the rationale.  As @stvnrlly pointed out, putting that explanation directly into the README could make it impossible to ever open the repo up since it would forever be part of the history (nasty git history rewrites notwithstanding).  Instead, maybe a Google doc and then a link in the README.

In any case, capturing the reasoning in a way that's easy to pull up later would be nice!  I'm no wordsmith, so if someone has better wording, let's have it!  😄 

Counterpart to 18F/handbook#335