### PR TITLE
Include issues in copyright interest waiver in CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ copyright and related rights in the work worldwide are waived through
 the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
 All contributions to this project will be released under the CC0
-dedication. By submitting a pull request, you are agreeing to comply
+dedication. By submitting a pull request or issue, you are agreeing to comply
 with this waiver of copyright interest.


### PR DESCRIPTION
Includes issues in the CONTRIBUTING file section about waiving copyright interest because pull requests are not the only way for people to contribute to a project; they can open issues as well.

**Question**:
Should we also add feedback via email and other methods?