### PR TITLE
Fix link style

### DIFF
--- a/policy.md
+++ b/policy.md
@@ -30,9 +30,7 @@ Code written entirely by 18F staff will be dedicated to the public domain. In ad
 
 Forks or clones of our code repositories are free to be re-distributed. This means code created by 18F can be integrated into work that is under a more restrictive license, even those that are not considered open source licenses.
 
-This changes when our code repositories include code that was not created by 18F and carries an open license. Code previously released under an open source license and then modified by 18F or its contractors is considered a ["joint work"] [4] and must be released under terms permitted by the original open source license.
-
-  [4]: http://www.copyright.gov/title17/92chap1.html#101 "Joint Work"
+This changes when our code repositories include code that was not created by 18F and carries an open license. Code previously released under an open source license and then modified by 18F or its contractors is considered a ["joint work"](http://www.copyright.gov/title17/92chap1.html#101) and must be released under terms permitted by the original open source license.
 
 The public can use our code as the basis of wholly proprietary and commercial systems. 18F would appreciate that users of our code disclose its lineage, but 18F maintains no legal right to require disclosure. Notifications that our work is used in a new system are always greatly appreciated.
 


### PR DESCRIPTION
The old link style must have been for some kind of a renderer, some Jekyll variant, that is no longer in use? The site, [as published](https://18f.gsa.gov/open-source-policy/), doesn't render this in any interesting way. Linking just the number `4` doesn't make any sense when reading through the rendered Markdown, and has no benefit when run through Jekyll, so I propose simply linking the text in question.